### PR TITLE
all arbitrary model return types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,8 @@ julia = "1"
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ArchGDAL", "HDF5", "Pkg", "Test"]
+test = ["ArchGDAL", "HDF5", "Pkg", "StaticArrays", "Test"]


### PR DESCRIPTION
This PR allows models to return arbitrary types. These must define base methods `+`, `*` and `zero`. The `initval` keyword lets you set the initial (ie zero) value for the output arrays. By default this is `zero` of the input data type. 

We may need to add a `maskval` keyword to deal with masking, and maybe allow `missing` masks.

@jaimesmaino the tests include an example for `StaticArrays`, wanna check out this branch to see if it does what you need before I merge?